### PR TITLE
Update openria nuget to 5.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,59 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Database.sdf
 *.mdf
 *.ldf
 /.vs
+.vs

--- a/OpenRiaServices.M2M.Client/OpenRiaServices.M2M.Client.csproj
+++ b/OpenRiaServices.M2M.Client/OpenRiaServices.M2M.Client.csproj
@@ -20,6 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenRiaServices.Client.Core" Version="5.0.0-rc0001" />
+    <PackageReference Include="OpenRiaServices.Client.Core" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/OpenRiaServices.M2M/OpenRiaServices.M2M.Server.csproj
+++ b/OpenRiaServices.M2M/OpenRiaServices.M2M.Server.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="OpenRiaServices.FluentMetadata" Version="5.0.0-rc.1" />
-    <PackageReference Include="OpenRiaServices.Server" Version="5.0.0-rc0001" />
-    <PackageReference Include="OpenRiaServices.T4" Version="5.0.0-rc0001" />
+    <PackageReference Include="OpenRiaServices.FluentMetadata" Version="5.0.0" />
+    <PackageReference Include="OpenRiaServices.Server" Version="5.0.0" />
+    <PackageReference Include="OpenRiaServices.T4" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update openria nuget to 5.0.0

We will have to wait until the 5.0 release of FluentMetadata nuget pagage is created until this can build.